### PR TITLE
Make subscription message filtering work

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -58,7 +58,7 @@ func main() {
 	}()
 
 	go func() {
-		time.Sleep(10 * time.Second)
+		time.Sleep(3 * time.Second)
 		sbPublisherConfig := &bus.PublisherConfig{
 			Region:                     *region,
 			Environment:                *environment,


### PR DESCRIPTION
Route commands to the correct worker using filter rules on Command DestinationId header